### PR TITLE
refactor: modularize helpers and document structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,10 @@ Tip (zsh): If you see `zsh: command not found: --burn-font`, you likely pasted a
 - SDK import errors: ensure `pip install -r requirements.txt`.
 - Empty or off timestamps: make sure ASR model supports `verbose_json` with segments (default `whisper-1` does).
   - If using `gpt-4o-transcribe` models, timestamps are not provided by the API; the script will produce a single-segment SRT spanning the file duration.
+
+## Code Structure
+
+- `tools/subtitle_gen.py`: CLI entry and orchestration.
+- `tools/fs_utils.py`: filesystem helpers and video discovery.
+- `tools/ffmpeg_utils.py`: ffmpeg audio extraction, burn-in, and font probing.
+- `main.py`: wrapper enabling burn-in by default for quick runs.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,2 @@
+"""Helper modules for the subtitle generator CLI."""
 

--- a/tools/ffmpeg_utils.py
+++ b/tools/ffmpeg_utils.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import subprocess
+from typing import Optional, Dict
+
+from .fs_utils import ensure_dirs
+
+
+def extract_audio_ffmpeg(video_path: str, audio_path: str, overwrite: bool = False) -> None:
+    if os.path.exists(audio_path) and not overwrite:
+        return
+    ensure_dirs(os.path.dirname(audio_path))
+    cmd = [
+        "ffmpeg", "-y" if overwrite else "-n",
+        "-i", video_path,
+        "-ac", "1",
+        "-ar", "16000",
+        "-vn",
+        audio_path,
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(e.stderr.decode(errors="ignore"))
+        raise
+
+
+def _ffmpeg_filter_quote(value: str) -> str:
+    return "'" + str(value).replace("'", r"\'") + "'"
+
+
+def burn_subtitles_ffmpeg(
+    video_path: str,
+    srt_path: str,
+    out_path: str,
+    font: str | None = None,
+    font_size: int | None = None,
+    margin_v: int | None = None,
+    fonts_dir: str | None = None,
+    show_progress: bool = False,
+) -> None:
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        ensure_dirs(out_dir)
+
+    style_parts = []
+    if font:
+        style_parts.append(f"FontName={font}")
+    if font_size:
+        style_parts.append(f"FontSize={int(font_size)}")
+    if margin_v:
+        style_parts.append(f"MarginV={int(margin_v)}")
+    force_style = ",".join(style_parts) if style_parts else None
+
+    filt = f"subtitles={_ffmpeg_filter_quote(srt_path)}:charenc=UTF-8"
+    if fonts_dir:
+        filt += f":fontsdir={_ffmpeg_filter_quote(fonts_dir)}"
+    if force_style:
+        filt += f":force_style={_ffmpeg_filter_quote(force_style)}"
+
+    out_ext = os.path.splitext(out_path)[1].lower()
+    cmd = ["ffmpeg", "-y"]
+    if show_progress:
+        cmd += ["-stats"]
+    cmd += ["-i", video_path, "-vf", filt]
+    if out_ext == ".webm":
+        cmd += ["-c:v", "libvpx-vp9", "-b:v", "2M", "-c:a", "libopus"]
+    else:
+        cmd += ["-c:v", "libx264", "-c:a", "copy"]
+    cmd += [out_path]
+    try:
+        if show_progress:
+            subprocess.run(cmd, check=True)
+        else:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(e.stderr.decode(errors="ignore"))
+        raise
+
+
+def detect_default_font() -> Dict[str, str | None]:
+    candidates = [
+        (os.path.join("fonts", "Noto_Sans_SC"), "Noto Sans SC"),
+        (os.path.join("fonts", "Noto Sans SC"), "Noto Sans SC"),
+        ("fonts", "Noto Sans SC"),
+    ]
+    for dir_path, family in candidates:
+        if os.path.isdir(dir_path):
+            try:
+                files = [f for f in os.listdir(dir_path) if f.lower().endswith((".ttf", ".otf"))]
+            except Exception:
+                files = []
+            if files or dir_path.endswith("Noto_Sans_SC") or dir_path.endswith("Noto Sans SC"):
+                return {"fonts_dir": dir_path, "font_name": family}
+    return {"fonts_dir": None, "font_name": None}
+
+
+def ffprobe_duration_seconds(path: str) -> float | None:
+    try:
+        proc = subprocess.run([
+            "ffprobe", "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1", path,
+        ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out = proc.stdout.decode().strip()
+        return float(out) if out else None
+    except Exception:
+        return None
+

--- a/tools/fs_utils.py
+++ b/tools/fs_utils.py
@@ -1,0 +1,25 @@
+import os
+from typing import List
+
+SUPPORTED_VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm"}
+
+
+def ensure_dirs(*dirs: str) -> None:
+    for d in dirs:
+        if d:
+            os.makedirs(d, exist_ok=True)
+
+
+def find_videos(src_dir: str) -> List[str]:
+    paths: List[str] = []
+    if not os.path.isdir(src_dir):
+        return paths
+    for entry in sorted(os.listdir(src_dir)):
+        p = os.path.join(src_dir, entry)
+        if not os.path.isfile(p):
+            continue
+        ext = os.path.splitext(p)[1].lower()
+        if ext in SUPPORTED_VIDEO_EXTS:
+            paths.append(p)
+    return paths
+

--- a/tools/subtitle_gen.py
+++ b/tools/subtitle_gen.py
@@ -6,9 +6,14 @@ import subprocess
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Any
 
+# Allow running as a script without requiring project root on sys.path
+if __package__ is None or __package__ == "":  # pragma: no cover
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tools"
+
 # New modular helpers
-from tools import fs_utils
-from tools.ffmpeg_utils import (
+from . import fs_utils
+from .ffmpeg_utils import (
     extract_audio_ffmpeg as _extract_audio_ffmpeg_impl,
     burn_subtitles_ffmpeg as _burn_subtitles_ffmpeg_impl,
     detect_default_font as _detect_default_font_impl,

--- a/tools/subtitle_gen.py
+++ b/tools/subtitle_gen.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Dict, Any
 
 # New modular helpers
-from tools.fs_utils import ensure_dirs, find_videos
+from tools import fs_utils
 from tools.ffmpeg_utils import (
     extract_audio_ffmpeg as _extract_audio_ffmpeg_impl,
     burn_subtitles_ffmpeg as _burn_subtitles_ffmpeg_impl,
@@ -156,12 +156,11 @@ def assemble_srt(blocks: List[Dict[str, Any]]) -> str:
 
 
 def ensure_dirs(*dirs: str) -> None:  # legacy wrapper
-    return None if not dirs else None  # no-op; imported from tools.fs_utils
+    fs_utils.ensure_dirs(*dirs)
 
 
 def find_videos(src_dir: str) -> List[str]:  # legacy wrapper
-    from tools.fs_utils import find_videos as _impl
-    return _impl(src_dir)
+    return fs_utils.find_videos(src_dir)
 
 
 def download_with_yt_dlp(


### PR DESCRIPTION
This PR refactors the codebase to improve maintainability and separation of concerns.\n\nChanges\n- Extract ffmpeg functionality to tools/ffmpeg_utils.py (audio extraction, burn-in, font detection, ffprobe).\n- Extract filesystem helpers to tools/fs_utils.py (ensure_dirs, find_videos).\n- Keep CLI stable by delegating legacy functions in tools/subtitle_gen.py to the new modules.\n- Add tools/__init__.py to mark the package.\n- Update README with a new Code Structure section.\n\nBehavior\n- No functional changes intended beyond code organization (features added earlier remain: yt-dlp download with progress/quiet, burn-in progress flag).\n\nReview\n- Focus on import paths and namespacing.\n- Sanity-check README references and CLI usage remain accurate.\n\nAfter merge\n- Consider extracting translation/ASR into their own modules in a follow-up.\n